### PR TITLE
Fix variable name in sigma network script

### DIFF
--- a/network/js/main.js
+++ b/network/js/main.js
@@ -115,7 +115,7 @@ function initSigma(config) {
         a.parseGexf(data,dataReady);
     else
 	    a.parseJson(data,dataReady);
-    gexf = sigmaInst = null;
+    gexf = sigInst = null;
 }
 
 


### PR DESCRIPTION
## Summary
- fix incorrect variable name when resetting global sigma instance

## Testing
- `git status --short`