### PR TITLE
Fix build by excluding node modules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,10 @@ plugins:
   - jekyll-octicons
   - jekyll-github-metadata
 
+# Avoid processing large example files that aren't part of the site
+exclude:
+  - claude_example
+
 titles_from_headings:
   enabled:     true
   strip_title: true


### PR DESCRIPTION
## Summary
- exclude `claude_example` directory from the site build

## Testing
- `git status --short`