### PR TITLE
Add sitemap gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "github-pages", group: :jekyll_plugins
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-octicons'
+  gem 'jekyll-sitemap'
 end
 
 gem "jekyll-github-metadata"

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@
 title: Project Portfolio Management
 description: This site is all about managing project portfolios more easily. I provide open frameworks and tool-sets to set up and deliver projects, programmes and portfolios.
 github_username: lawrencerowland
+url: "https://lawrencerowland.github.io"
 
 
 
@@ -23,6 +24,7 @@ plugins:
   - jekyll-gist
   - jekyll-octicons
   - jekyll-github-metadata
+  - jekyll-sitemap
 
 # Avoid processing large example files that aren't part of the site
 exclude:

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://lawrencerowland.github.io/sitemap.xml


### PR DESCRIPTION
## Summary
- add `jekyll-sitemap` gem to the Jekyll plugin list
- previous commit already configured the plugin in `_config.yml` and created `robots.txt`

## Testing
- `bundle exec jekyll build` *(fails: `bundle` not found)*