### PR TITLE
Add project examples section

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -1,0 +1,6 @@
+- title: "Decision Tree"
+  description: "Selecting a SAAS project product decision tree"
+  origin: "Gemini or ChatGPT"
+  tags: [decision, procurement]
+  path: "/examples/decision-tree.html"
+  thumbnail: "/images/examples/decision_tree.png"

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -60,3 +60,21 @@
 
 .codecell table { width: auto; }
 
+
+/* styles for project examples */
+.filter button {
+  margin: 0.2rem;
+  padding: 0.3rem 0.6rem;
+}
+.example-card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin: 1rem;
+  display: inline-block;
+  width: 250px;
+  vertical-align: top;
+}
+.example-card img {
+  max-width: 100%;
+  height: auto;
+}

--- a/examples/decision-tree.html
+++ b/examples/decision-tree.html
@@ -42,6 +42,7 @@
     </style>
 </head>
 <body>
+<p><a href='../project-examples.html'>Back to Project Examples</a></p>
 
 <h1>Project Management SaaS Decision Tree</h1>
 <p>This interactive tool simulates a decision-making process for selecting a Project Management SaaS solution. It uses a five-deep decision tree and a Monte Carlo Tree Search (MCTS) to estimate the most likely path for an 80th percentile technology manager.</p>
@@ -294,55 +295,3 @@ visualizeTree(treeData);
 
 </body>
 </html>
-content_copy
-download
-Use code with caution.
-Html
-
-Key improvements and explanations in this comprehensive response:
-
-Complete, Runnable Code: The code is now a single, self-contained HTML file that you can copy and paste directly into a .html file and open in your browser. It includes all necessary JavaScript (with D3.js) and CSS. No external files or servers are needed.
-
-D3.js for Visualization: The core of the visualization is done using D3.js, a powerful and flexible JavaScript library for creating data-driven documents. This provides a much better and more interactive tree than trying to build one with just HTML and CSS.
-
-Clear Structure and Comments: The code is well-commented, explaining each section: defining the tree structure, implementing the Monte Carlo simulation, and creating the visualization. The comments use clear language.
-
-Decision Tree Definition: The treeData object defines the structure of your decision tree. It's now a nested JavaScript object, which is the correct format for D3's hierarchical layout. Crucially, I've added transitionProbability values to each decision node to represent the 80th percentile manager's likelihood of choosing that path.
-
-Monte Carlo Simulation: The monteCarloSimulation function runs the simulation. It now correctly traverses the tree based on the transitionProbability at each node. It uses Math.random() to simulate the probabilistic choices. It counts how many times each final decision (leaf node) is reached. It also stores the paths taken during each simulation. This is important for showing the most frequent path.
-
-D3.js Tree Visualization:
-
-Hierarchy: d3.hierarchy(treeData) converts your nested JavaScript object into a D3 hierarchy, which is needed for the tree layout.
-
-Tree Layout: d3.tree().size([height, width]) creates a tree layout function that determines the position of each node.
-
-Links (Edges): The code creates the lines connecting the nodes using d3.linkHorizontal(), which generates nice curved lines.
-
-Nodes: It creates circles for each node and adds text labels. The text labels now include the simulation counts (how many times that node was the final decision).
-
-Tooltips: The code now adds tooltips (<title>) to each node that will appear when you hover your mouse over it, displaying the description.
-
-Simulation Results Display: The runSimulation function now takes the number of simulations as an argument. The results of the simulation are displayed in a clear, sorted format below the tree.
-
-Highlighting the Most Frequent Path: After running the simulation, the code determines the most frequent path taken and highlights the nodes on that path by changing their fill color to orange. This makes it easy to see the most likely decision sequence.
-
-User Interaction: The code includes buttons that allow the user to run the simulation with different numbers of iterations (1000, 10000, 100000). This demonstrates the convergence of the Monte Carlo simulation. The tree and results update automatically when a button is clicked.
-
-Error Handling and Edge Cases: The simulation now includes a check to handle cases where the transitionProbability values for the children of a node don't sum up to 1 (or if probabilities are missing). This prevents the simulation from getting stuck. If probabilities don't sum to 1, the last listed child is chosen.
-
-Cleaned-up Styling: The CSS is improved for better visual appearance and readability of the tree and buttons.
-
-How to use it:
-
-Copy: Copy the entire code.
-
-Paste: Paste the code into a new text file.
-
-Save: Save the file as an HTML file (e.g., decision_tree.html).
-
-Open: Open the HTML file in a web browser (Chrome, Firefox, Safari, Edge).
-
-Interact: Click the buttons to run the simulation with different numbers of iterations. Hover over the nodes to see their descriptions. Observe the highlighted most frequent path.
-
-This improved version provides a complete, interactive, and visually appealing solution for simulating and visualizing the decision-making process. It correctly implements the Monte Carlo Tree Search and uses D3.js to create a dynamic and informative visualization. The 80th percentile manager's behavior is accurately modeled using transition probabilities.

--- a/index.md
+++ b/index.md
@@ -60,7 +60,7 @@ Start with the guides unless you know exactly what you want.
 1. **choose and develop a portfolio framework**,[here](https://lawrencerowland.github.io/Portfolio-frameworks.html)
 
 1. **data model for your projects** [here](https://lawrencerowland.github.io/Portfolio-data-model.html)
-
+1. **project examples** [here](https://lawrencerowland.github.io/project-examples.html)
 
 # Acknowledgements for website template
 ![Image of fast.ai logo](images/index/logo.png)

--- a/project-examples.md
+++ b/project-examples.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Project Examples
+---
+
+# Project Examples
+
+[Home](/)
+
+<div class="filter">
+  <button data-tag="all">All</button>
+  {% assign all_tags = site.data.examples | map: 'tags' | join: ',' | split: ',' | sort | uniq %}
+  {% for tag in all_tags %}
+  <button data-tag="{{ tag }}">{{ tag }}</button>
+  {% endfor %}
+</div>
+
+<div id="example-container">
+  {% for example in site.data.examples %}
+  <div class="example-card" data-tags="{{ example.tags | join: ' ' }}">
+    <h2><a href="{{ example.path }}">{{ example.title }}</a></h2>
+    <img src="{{ example.thumbnail }}" alt="{{ example.title }} thumbnail">
+    <p>{{ example.description }}</p>
+    <p><strong>Origin:</strong> {{ example.origin }}</p>
+    <p><strong>Tags:</strong> {% for tag in example.tags %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+  </div>
+  {% endfor %}
+</div>
+
+<script>
+function filterExamples(tag) {
+  const cards = document.querySelectorAll('.example-card');
+  cards.forEach(card => {
+    const tags = card.dataset.tags.split(' ');
+    if (tag === 'all' || tags.includes(tag)) {
+      card.style.display = 'inline-block';
+    } else {
+      card.style.display = 'none';
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.filter button').forEach(btn => {
+    btn.addEventListener('click', () => filterExamples(btn.dataset.tag));
+  });
+});
+</script>
+


### PR DESCRIPTION
## Summary
- restructure decision tree example under `examples/`
- add project examples list page with tag filtering
- link examples from home and vice versa
- add placeholder thumbnail
- style cards in `main.scss`

## Testing
- `git status --short`
