### PR TITLE
Remove example thumbnails

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -3,22 +3,18 @@
   origin: "Gemini or ChatGPT"
   tags: [decision, procurement]
   path: "/examples/decision-tree.html"
-  thumbnail: "/images/examples/decision_tree.png"
 - title: "Grounded Theory as Colimit"
   description: "Interactive visualisation of grounded theory through a category theory lens"
   origin: "ChatGPT"
   tags: [category theory, methods, social-science, knowledge-management]
   path: "/examples/grounded-theory-colimit.html"
-  thumbnail: "/images/examples/decision_tree.png"
 - title: "HS2 decision graph"
   description: "HS2 Supply Chain Risk and Value Decision Making Knowledge Graph"
   origin: "Claude 3.7 Sonnet"
   tags: [knowledge-graph, ontology, risk, value, rail, decision]
   path: "/examples/hs2-decision-graph.html"
-  thumbnail: "/images/examples/decision_tree.png"
 - title: "Petri to WBS"
   description: "Toy shed build model using Petri nets to generate SMC morphisms and candidate WBS schedules."
   origin: "ChatGPT o3"
   tags: [category theory, WBS, petri net, generative model, possible futures]
   path: "/examples/petri-to-wbs.html"
-  thumbnail: "/images/examples/decision_tree.png"

--- a/project-examples.md
+++ b/project-examples.md
@@ -19,7 +19,6 @@ title: Project Examples
   {% for example in site.data.examples %}
   <div class="example-card" data-tags="{{ example.tags | join: ' ' }}">
     <h2><a href="{{ example.path }}">{{ example.title }}</a></h2>
-    <img src="{{ example.thumbnail }}" alt="Illustration for {{ example.title }}">
     <p>{{ example.description }}</p>
     <p><strong>Origin:</strong> {{ example.origin }}</p>
     <p><strong>Tags:</strong> {% for tag in example.tags %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>


### PR DESCRIPTION
## Summary
- remove references to unused example thumbnails
- drop `thumbnail` field from example data

## Testing
- `npm test` *(fails: could not find package.json)*
- `bundle exec jekyll build` *(fails: bundler error)*