### PR TITLE
Add blog page and navigation links

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,6 +10,7 @@
       <li><a href="{{ '/Portfolio-frameworks.html' | relative_url }}" {% if page.url == '/Portfolio-frameworks.html' %}class="active"{% endif %}>Frameworks</a></li>
       <li><a href="{{ '/project-examples.html' | relative_url }}" {% if page.url == '/project-examples.html' %}class="active"{% endif %}>Examples</a></li>
       <li><a href="{{ '/graphs.html' | relative_url }}" {% if page.url == '/graphs.html' %}class="active"{% endif %}>Graphs</a></li>
+      <li><a href="{{ '/blog.html' | relative_url }}" {% if page.url == '/blog.html' %}class="active"{% endif %}>Blog</a></li>
       <li><a href="{{ '/about.html' | relative_url }}" {% if page.url == '/about.html' %}class="active"{% endif %}>About</a></li>
     </ul>
   </div>

--- a/_posts/2020-05-08-Applying appropriate machine-learning approach.md
+++ b/_posts/2020-05-08-Applying appropriate machine-learning approach.md
@@ -58,3 +58,5 @@ Please go to the relevant code and document library[here](https://github.com/law
 
 # Acknowledgements
 Agrawal et al have a canvas [here](https://predictionmachines.ai) for planning it at high level, understanding purpose and constraints.
+
+[Back to Blog]({{ '/blog.html' | relative_url }})

--- a/_posts/2020-05-16-Adopt-existing-portfolio-framework.md
+++ b/_posts/2020-05-16-Adopt-existing-portfolio-framework.md
@@ -28,3 +28,5 @@ Adopt an existing portfolio framework
 Howard Lewis set out the event triggers and client needs. 
 
 
+
+[Back to Blog]({{ '/blog.html' | relative_url }})

--- a/_posts/2020-06-20-Project-management-jobs-to-be-done.md
+++ b/_posts/2020-06-20-Project-management-jobs-to-be-done.md
@@ -26,3 +26,5 @@ Clayton Christensen would always ask, when it came to a service or a product, wh
 
 # Acknowledgements
 Christensen
+
+[Back to Blog]({{ '/blog.html' | relative_url }})

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Blog
+---
+
+# Blog Posts
+
+<ul>
+{% for post in site.posts %}
+  <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> <small>{{ post.date | date: '%Y-%m-%d' }}</small></li>
+{% endfor %}
+</ul>
+


### PR DESCRIPTION
## Summary
- add a Blog page listing all posts
- link to the blog from the site navigation
- add "Back to Blog" links at the end of each post

## Testing
- `bundle install` *(fails: Could not fetch specs)*