### PR TITLE
Add local dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@ The website is published [here](https://lawrencerowland.github.io): it has been 
 Or the code and document repositories are available from [my main Github page](https://github.com/lawrencerowland)
 
 Lawrence
+
+## Local development
+
+This site is a standard Jekyll project. To run it locally you need a working Ruby
+environment with [Bundler](https://bundler.io/) installed. Once Ruby and
+Bundler are available, install the dependencies and serve the site with:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+The website will then be available at `http://localhost:4000`.
+
+The interactive examples under [`examples/`](examples/) are regular HTML files
+and can also be opened directly in a browser if you prefer to run them outside
+of Jekyll.


### PR DESCRIPTION
## Summary
- add instructions for running the site locally with Bundler
- note that HTML examples work standalone

## Testing
- `bundle install` *(fails: could not reach rubygems.org)*