### PR TITLE
Improve gwern-like styling

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
@@ -53,5 +56,6 @@
   }
   window.onload = wrap_img;
   </script>
+  <script src="{{ '/assets/footnotes.js' | relative_url }}"></script>
 
 </head>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,14 +3,8 @@
     <a class="logo" href="{{ '/' | relative_url }}">Home</a>
     <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
     <ul class="nav-links">
-      <li><a href="{{ '/' | relative_url }}" {% if page.url == '/' %}class="active"{% endif %}>Home</a></li>
-      <li><a href="{{ '/Books.html' | relative_url }}" {% if page.url == '/Books.html' %}class="active"{% endif %}>Books</a></li>
-      <li><a href="{{ '/ML-for-portfolios.html' | relative_url }}" {% if page.url == '/ML-for-portfolios.html' %}class="active"{% endif %}>ML for portfolios</a></li>
-      <li><a href="{{ '/Portfolio-data-model.html' | relative_url }}" {% if page.url == '/Portfolio-data-model.html' %}class="active"{% endif %}>Data models</a></li>
-      <li><a href="{{ '/Portfolio-frameworks.html' | relative_url }}" {% if page.url == '/Portfolio-frameworks.html' %}class="active"{% endif %}>Frameworks</a></li>
-      <li><a href="{{ '/project-examples.html' | relative_url }}" {% if page.url == '/project-examples.html' %}class="active"{% endif %}>Examples</a></li>
-      <li><a href="{{ '/graphs.html' | relative_url }}" {% if page.url == '/graphs.html' %}class="active"{% endif %}>Graphs</a></li>
       <li><a href="{{ '/blog.html' | relative_url }}" {% if page.url == '/blog.html' %}class="active"{% endif %}>Blog</a></li>
+      <li><a href="{{ '/project-examples.html' | relative_url }}" {% if page.url == '/project-examples.html' %}class="active"{% endif %}>Examples</a></li>
       <li><a href="{{ '/about.html' | relative_url }}" {% if page.url == '/about.html' %}class="active"{% endif %}>About</a></li>
     </ul>
   </div>

--- a/assets/footnotes.js
+++ b/assets/footnotes.js
@@ -1,0 +1,15 @@
+// Simple footnote hover popups
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('sup.footnote-ref').forEach(ref => {
+    const link = ref.querySelector('a');
+    if (!link) return;
+    const id = link.getAttribute('href');
+    if (!id) return;
+    const note = document.querySelector(id);
+    if (!note) return;
+    const popup = document.createElement('span');
+    popup.className = 'footnote-popup';
+    popup.innerHTML = note.innerHTML;
+    ref.appendChild(popup);
+  });
+});

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,6 +4,90 @@
 
 @import "{{ site.theme }}";
 
+body {
+  font-family: Georgia, "Times New Roman", serif;
+  background: #f5f5f5;
+  line-height: 1.6;
+  color: #333;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Inter', Arial, sans-serif;
+  font-weight: 600;
+}
+
+.page-content {
+  max-width: 40rem;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 2rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}
+
+a {
+  color: #703030;
+}
+a:hover {
+  color: #502020;
+}
+
+.navbar {
+  position: relative;
+  background: none;
+  border-bottom: none;
+  margin-bottom: 1rem;
+}
+.nav-links {
+  font-size: 0.9rem;
+}
+.nav-links li {
+  margin-left: 0.5rem;
+}
+.nav-toggle {
+  font-size: 1.2rem;
+}
+
+figure.image {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+sup.footnote-ref {
+  position: relative;
+}
+.footnote-popup {
+  display: none;
+  position: absolute;
+  top: 1.2em;
+  left: 0;
+  background: #f8f8f8;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  max-width: 200px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  z-index: 100;
+}
+sup.footnote-ref:hover .footnote-popup {
+  display: block;
+}
+
+.footnotes {
+  border-top: 1px solid #ccc;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  font-size: 0.9rem;
+}
+
+#markdown-toc {
+  background: #fafafa;
+  border: 1px solid #eee;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
 .post img {
         display: block;
         border:1px solid #021a40;
@@ -79,14 +163,7 @@
   height: auto;
 }
 
-/* Navbar styles */
-.navbar {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  border-bottom: 1px solid #ddd;
-  z-index: 1000;
-}
+/* Navbar layout */
 .nav-container {
   display: flex;
   align-items: center;
@@ -109,7 +186,6 @@
   display: none;
   background: none;
   border: none;
-  font-size: 1.5rem;
 }
 @media (max-width: 600px) {
   .nav-links {


### PR DESCRIPTION
## Summary
- load Inter font and footnote script in the document head
- simplify navigation links
- implement gwern-inspired CSS for layout, typography and footnotes
- add footnote popup JavaScript

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: could not fetch specs)*