### PR TITLE
Add bundler setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing bundler 2.1.4"
+gem install bundler -v 2.1.4
+
+bundle _2.1.4_ install


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for Codex setup

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*