### PR TITLE
Restore navigation links

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,8 +3,16 @@
     <a class="logo" href="{{ '/' | relative_url }}">Home</a>
     <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
     <ul class="nav-links">
-      <li><a href="{{ '/blog.html' | relative_url }}" {% if page.url == '/blog.html' %}class="active"{% endif %}>Blog</a></li>
+      <li><a href="{{ '/' | relative_url }}" {% if page.url == '/' %}class="active"{% endif %}>Home</a></li>
+      <li><a href="{{ '/Books.html' | relative_url }}" {% if page.url == '/Books.html' %}class="active"{% endif %}>Books</a></li>
+      <li><a href="{{ '/ML-for-portfolios.html' | relative_url }}" {% if page.url == '/ML-for-portfolios.html' %}class="active"{% endif %}>ML for portfolios</a></li>
+      <li><a href="{{ '/Portfolio-data-model.html' | relative_url }}" {% if page.url == '/Portfolio-data-model.html' %}class="active"{% endif %}>Data models</a></li>
+      <li><a href="{{ '/Portfolio-frameworks.html' | relative_url }}" {% if page.url == '/Portfolio-frameworks.html' %}class="active"{% endif %}>Frameworks</a></li>
+      <li><a href="{{ '/graphs.html' | relative_url }}" {% if page.url == '/graphs.html' %}class="active"{% endif %}>Graphs</a></li>
       <li><a href="{{ '/project-examples.html' | relative_url }}" {% if page.url == '/project-examples.html' %}class="active"{% endif %}>Examples</a></li>
+      <li><a href="{{ '/side-projects.html' | relative_url }}" {% if page.url == '/side-projects.html' %}class="active"{% endif %}>Side Projects</a></li>
+      <li><a href="{{ '/blog_summary.html' | relative_url }}" {% if page.url == '/blog_summary.html' %}class="active"{% endif %}>Blog Summary</a></li>
+      <li><a href="{{ '/blog.html' | relative_url }}" {% if page.url == '/blog.html' %}class="active"{% endif %}>Blog</a></li>
       <li><a href="{{ '/about.html' | relative_url }}" {% if page.url == '/about.html' %}class="active"{% endif %}>About</a></li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- restore links in navbar to pages like Books, Frameworks, and Graphs

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*