### PR TITLE
Add custom GPT placeholder page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -11,6 +11,7 @@
       <li><a href="{{ '/graphs.html' | relative_url }}" {% if page.url == '/graphs.html' %}class="active"{% endif %}>Graphs</a></li>
       <li><a href="{{ '/Books.html' | relative_url }}" {% if page.url == '/Books.html' %}class="active"{% endif %}>Books</a></li>
       <li><a href="{{ '/side-projects.html' | relative_url }}" {% if page.url == '/side-projects.html' %}class="active"{% endif %}>Side Projects</a></li>
+      <li><a href="{{ '/my-custom-gpts.html' | relative_url }}" {% if page.url == '/my-custom-gpts.html' %}class="active"{% endif %}>My Custom GPTs</a></li>
       <li><a href="{{ '/blog_summary.html' | relative_url }}" {% if page.url == '/blog_summary.html' %}class="active"{% endif %}>Blog Summary</a></li>
       <li><a href="{{ '/blog.html' | relative_url }}" {% if page.url == '/blog.html' %}class="active"{% endif %}>Blog</a></li>
       <li><a href="{{ '/about.html' | relative_url }}" {% if page.url == '/about.html' %}class="active"{% endif %}>About</a></li>

--- a/my-custom-gpts.md
+++ b/my-custom-gpts.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: My Custom GPTs
+schema_type: CollectionPage
+tags: [CustomGPT, AI]
+---
+
+# My Custom GPTs
+
+[Home](/)
+
+This placeholder page will gather links to custom GPT projects and resources.
+
+- [Side Projects](/side-projects.html)
+- [Blog Summary](/blog_summary.html)
+

--- a/side-projects.md
+++ b/side-projects.md
@@ -8,6 +8,7 @@ tags: [SideProjects, Examples]
 # Side Projects
 
 [Home](/)
+[My Custom GPTs](/my-custom-gpts.html)
 
 <div class="filter">
   <button data-tag="all">All</button>


### PR DESCRIPTION
## Summary
- add a placeholder **My Custom GPTs** page
- link the new page in the main navigation
- link to it from the Side Projects page

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_684381fc71e8833282ceec5c9914eb58