### PR TITLE
Fix tags order

### DIFF
--- a/project-examples.md
+++ b/project-examples.md
@@ -23,7 +23,7 @@ tags: [Examples, Visualization, KnowledgeManagement]
     <h2><a href="{{ example.path }}">{{ example.title }}</a></h2>
     <p>{{ example.description }}</p>
     <p><strong>Origin:</strong> {{ example.origin }}</p>
-    <p><strong>Tags:</strong> {% for tag in example.tags %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+    <p><strong>Tags:</strong> {% for tag in example.tags | sort %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
   </div>
   {% endfor %}
 </div>

--- a/side-projects.md
+++ b/side-projects.md
@@ -24,7 +24,7 @@ tags: [SideProjects, Examples]
     <h2><a href="{{ project.path }}">{{ project.title }}</a></h2>
     <p>{{ project.description }}</p>
     <p><strong>Origin:</strong> {{ project.origin }}</p>
-    <p><strong>Tags:</strong> {% for tag in project.tags %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+    <p><strong>Tags:</strong> {% for tag in project.tags | sort %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- order example tags alphabetically
- order side project tags alphabetically

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: No repo name found)*

------
https://chatgpt.com/codex/tasks/task_e_68571650c1948332906834a2a24f86a7