### PR TITLE
Fix project web app image paths

### DIFF
--- a/all-project-apps.md
+++ b/all-project-apps.md
@@ -61,7 +61,10 @@ function createCards(data) {
       img.src = imgName;
     } else {
       const ext = /\.(png|jpg|jpeg|gif|svg)$/i.test(imgName) ? '' : '.png';
-      img.src = '/' + item.repo + '/pics/' + imgName + ext;
+      const base = item.repo === 'Project-web-apps'
+        ? '/Project-web-apps/web_apps/pics/'
+        : '/' + item.repo + '/pics/';
+      img.src = base + imgName + ext;
     }
     img.alt = item.name;
     card.appendChild(img);


### PR DESCRIPTION
## Summary
- all-project-apps page builds cards from two CSV files
- fix `Project-web-apps` image path so its images render correctly

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686a779eba1c8332b3fe0c905ef62a29