### PR TITLE
Fix layout overflow

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -25,7 +25,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .page-content.wide {
-  max-width: 80rem;
+  max-width: 96rem;
 }
 
 a {


### PR DESCRIPTION
## Summary
- widen `.page-content.wide` container so cards fit within the layout

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686afafb26148332ba6f7649e221f732