### PR TITLE
Add heatmap overview to project apps

### DIFF
--- a/all-project-apps.md
+++ b/all-project-apps.md
@@ -24,12 +24,27 @@ wide: true
     height: auto;
     margin-bottom: 0.5em;
   }
+  #heatmap-container {
+    display: flex;
+    height: 1.5em;
+    margin: 0.5em 0;
+    border: 1px solid #ccc;
+  }
+  #heatmap-container .heat-segment {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 0.8em;
+  }
 </style>
 
 
 # All Project Apps
 
 <div id="filter-container" class="filter"></div>
+
+<div id="heatmap-container" class="heatmap"></div>
 
 <div id="app-container"></div>
 
@@ -118,6 +133,17 @@ const canonicalMap = {
 };
 
 const canonicalCategories = ['all', ...Array.from(new Set(Object.values(canonicalMap)))];
+
+const colorMap = {
+  strategy_portfolio: '#e41a1c',
+  ai_data: '#377eb8',
+  complexity_systems: '#4daf4a',
+  governance_controls: '#984ea3',
+  decision_intelligence: '#ff7f00',
+  stakeholders_culture: '#ffff33',
+  learning_capability: '#a65628',
+  value_benefits: '#f781bf'
+};
 
 function parseCSV(text) {
   const lines = text.trim().split(/\r?\n/);
@@ -230,6 +256,30 @@ function createCards(data) {
   });
 }
 
+function renderHeatmap(data) {
+  const counts = {};
+  data.forEach(item => {
+    const tagField = item.tags || item.tag || item.keywords || item.categories || '';
+    const cats = new Set();
+    tagField.split(/[,;]/).map(t => t.trim().toLowerCase()).forEach(t => {
+      if (canonicalMap[t]) cats.add(canonicalMap[t]);
+    });
+    cats.forEach(cat => { counts[cat] = (counts[cat] || 0) + 1; });
+  });
+  canonicalCategories.slice(1).forEach(cat => { if (!counts[cat]) counts[cat] = 0; });
+  const container = document.getElementById('heatmap-container');
+  container.innerHTML = '';
+  Object.entries(counts).forEach(([cat, count]) => {
+    const seg = document.createElement('div');
+    seg.className = 'heat-segment';
+    seg.style.flexGrow = count;
+    seg.style.background = colorMap[cat] || '#999';
+    seg.title = cat + ': ' + count;
+    seg.textContent = count;
+    container.appendChild(seg);
+  });
+}
+
 function setActiveCategory(category) {
   document.querySelectorAll('#filter-container button').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.tag === category);
@@ -271,6 +321,7 @@ function loadData() {
     createFilters(canonicalCategories);
     createTagCloud(allTags);
     createCards(data);
+    renderHeatmap(data);
   });
 }
 

--- a/project-examples.md
+++ b/project-examples.md
@@ -11,7 +11,7 @@ tags: [Examples, Visualization, KnowledgeManagement]
 
 <div class="filter">
   <button data-tag="all">All</button>
-  {% assign all_tags = site.data.examples | map: 'tags' | join: ',' | split: ',' | sort | uniq %}
+  {% assign all_tags = site.data.examples | map: 'tags' | join: ',' | split: ',' | uniq | sort %}
   {% for tag in all_tags %}
   <button data-tag="{{ tag }}">{{ tag }}</button>
   {% endfor %}
@@ -23,7 +23,7 @@ tags: [Examples, Visualization, KnowledgeManagement]
     <h2><a href="{{ example.path }}">{{ example.title }}</a></h2>
     <p>{{ example.description }}</p>
     <p><strong>Origin:</strong> {{ example.origin }}</p>
-    <p><strong>Tags:</strong> {% for tag in example.tags | sort %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+    <p><strong>Tags:</strong> {% for tag in example.tags %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
   </div>
   {% endfor %}
 </div>

--- a/side-projects.md
+++ b/side-projects.md
@@ -12,7 +12,7 @@ tags: [SideProjects, Examples]
 
 <div class="filter">
   <button data-tag="all">All</button>
-  {% assign all_tags = site.data.side_projects | map: 'tags' | join: ',' | split: ',' | sort | uniq %}
+  {% assign all_tags = site.data.side_projects | map: 'tags' | join: ',' | split: ',' | uniq | sort %}
   {% for tag in all_tags %}
   <button data-tag="{{ tag }}">{{ tag }}</button>
   {% endfor %}
@@ -24,7 +24,7 @@ tags: [SideProjects, Examples]
     <h2><a href="{{ project.path }}">{{ project.title }}</a></h2>
     <p>{{ project.description }}</p>
     <p><strong>Origin:</strong> {{ project.origin }}</p>
-    <p><strong>Tags:</strong> {% for tag in project.tags | sort %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+    <p><strong>Tags:</strong> {% for tag in project.tags %}<span class="tag">{{ tag }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- display a new heatmap bar on the `All Project Apps` page
- include colours for each canonical category
- show counts in the bar after data loads
- fix Liquid tag warnings in project listing pages

## Testing
- `PAGES_REPO_NWO=lawrencerowland.github.io bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686d05e8c1e083328e9cda702661bd8c