### PR TITLE
Fix heatmap ordering

### DIFF
--- a/all-project-apps.md
+++ b/all-project-apps.md
@@ -258,18 +258,19 @@ function createCards(data) {
 
 function renderHeatmap(data) {
   const counts = {};
+  canonicalCategories.slice(1).forEach(cat => { counts[cat] = 0; });
   data.forEach(item => {
     const tagField = item.tags || item.tag || item.keywords || item.categories || '';
     const cats = new Set();
     tagField.split(/[,;]/).map(t => t.trim().toLowerCase()).forEach(t => {
       if (canonicalMap[t]) cats.add(canonicalMap[t]);
     });
-    cats.forEach(cat => { counts[cat] = (counts[cat] || 0) + 1; });
+    cats.forEach(cat => { counts[cat] += 1; });
   });
-  canonicalCategories.slice(1).forEach(cat => { if (!counts[cat]) counts[cat] = 0; });
   const container = document.getElementById('heatmap-container');
   container.innerHTML = '';
-  Object.entries(counts).forEach(([cat, count]) => {
+  canonicalCategories.slice(1).forEach(cat => {
+    const count = counts[cat];
     const seg = document.createElement('div');
     seg.className = 'heat-segment';
     seg.style.flexGrow = count;


### PR DESCRIPTION
## Summary
- compute heatmap counts in a fixed order
- render heatmap segments consistently

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686d08c76d3c8332a8b1aad95ad254f5