### PR TITLE
Fix gap-map filter listener

### DIFF
--- a/gap-map.md
+++ b/gap-map.md
@@ -380,12 +380,15 @@ function buildDomainFilters(){
     label.innerHTML=`<input type="checkbox" id="${id}" data-domain="${d}" checked> ${d}`;
     container.appendChild(label);
   });
-  container.addEventListener('change',e=>{
-    if(e.target.type==='checkbox'){
-      const domain=e.target.dataset.domain;
-      if(e.target.checked){activeDomains.delete(domain);}else{activeDomains.add(domain);}renderList();
-    }
-  });
+  if(!container.dataset.listener){
+    container.addEventListener('change',e=>{
+      if(e.target.type==='checkbox'){
+        const domain=e.target.dataset.domain;
+        if(e.target.checked){activeDomains.delete(domain);}else{activeDomains.add(domain);}renderList();
+      }
+    });
+    container.dataset.listener='true';
+  }
 }
 
 // Returns true if the item should be visible given the currently unchecked


### PR DESCRIPTION
## Summary
- avoid attaching multiple listeners when rebuilding domain filters

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687031b1c3fc833298fc3ec0893c9bb8