### PR TITLE
Add legacy app tag mappings

### DIFF
--- a/gap-map.md
+++ b/gap-map.md
@@ -278,6 +278,16 @@ const canonicalMap = {
   predictive_modeling: ['technology_integration', 'risk_management'],
   sustainability: ['project_governance', 'stakeholder_engagement'],
   training: ['leadership_team', 'emerging_practice']
+
+  // Legacy App tags mapped to current taxonomy
+  strategy_portfolio: 'portfolio_management',
+  ai_data: 'technology_integration',
+  complexity_systems: 'innovation_pm',
+  governance_controls: ['project_governance', 'project_controls'],
+  decision_intelligence: 'risk_management',
+  stakeholders_culture: 'stakeholder_engagement',
+  learning_capability: 'emerging_practice',
+  value_benefits: 'project_evaluation'
 };
 
 const canonicalToDomain = {


### PR DESCRIPTION
## Summary
- map older legacy tags to the canonical taxonomy used in the Gap Map

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6872d2763e848332afd8b62f2a7bd28c