### PR TITLE
Fix slugify scope in gap-map script

### DIFF
--- a/gap-map.md
+++ b/gap-map.md
@@ -336,8 +336,11 @@ const tagToCaps = {
   resources: ['C16']
 };
 
+function slugify(str){
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
 function parseCSV(text){
-function slugify(str){return str.toLowerCase().replace(/[^a-z0-9]+/g,"-");}
   const lines=text.trim().split(/\r?\n/);
   const headers=lines.shift().split(',').map(h=>h.trim().toLowerCase());
   return lines.map(line=>{


### PR DESCRIPTION
## Summary
- define `slugify` globally in `gap-map.md`
- call global function when generating resource slugs

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6872e338c63c8332b6f1b6eebcb0bd9f