### PR TITLE
Sort app resources first in gap map

### DIFF
--- a/gap-map.md
+++ b/gap-map.md
@@ -381,6 +381,12 @@ function integrateApps(apps){
     data.resources.push(resource);
     tags.forEach(t=>{const caps=tagToCaps[t]; if(caps){caps.forEach(cid=>{const cap=data.capabilities.find(c=>c.id===cid); if(cap && !cap.linkedResources.includes(resId)) cap.linkedResources.push(resId); if(!resource.linkedCapabilities.includes(cid)) resource.linkedCapabilities.push(cid);});}});
   });
+  // Ensure resources from apps appear first in listings
+  data.resources.sort((a,b)=>{
+    if(a.fromApp && !b.fromApp) return -1;
+    if(!a.fromApp && b.fromApp) return 1;
+    return 0;
+  });
 }
 
 function loadResourcesData(){


### PR DESCRIPTION
## Summary
- keep resources from project apps sorted to the top of the list

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6873775e899c8332b31e1445b66f293c