### PR TITLE
Add tooltips for graph nodes

### DIFF
--- a/gap-map.md
+++ b/gap-map.md
@@ -590,6 +590,7 @@ function drawGraph(){
     });
 
   nodeGroup.append('circle').attr('class','node').attr('id',d=>`node-${d.id}`).attr('r',8).attr('fill',d=>color[d.type]);
+  nodeGroup.append('title').text(d=>d.title);
   nodeGroup.filter(d=>d.fromApp).append('circle').attr('class','app-ring').attr('r',12);
 
   simulation.on('tick',()=>{


### PR DESCRIPTION
## Summary
- show a browser tooltip on nodes in `gap-map.md`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687381b52b088332a0f173126dcd265d