### PR TITLE
Remove footer from gap map

### DIFF
--- a/gap-map.md
+++ b/gap-map.md
@@ -58,7 +58,7 @@ main{flex:1;display:flex;overflow:hidden;position:relative;}
 .modal-content h2{margin-top:0;}
 .close-button{color:#aaa;float:right;font-size:28px;font-weight:bold;cursor:pointer;}
 @media (max-width:768px){h1{font-size:1.1rem;}header{flex-direction:column;align-items:flex-start;}.controls-right{margin-left:0;}#filters{flex-direction:column;align-items:stretch;}}
-footer.site-footer{padding:0.25rem 0;font-size:0.8rem;}
+footer.site-footer{display:none}
 .app-ring{fill:none;stroke:var(--highlight);stroke-width:2px;}
 .link.highlighted{stroke:var(--highlight)!important;stroke-width:3px;}
 </style>


### PR DESCRIPTION
## Summary
- hide the site footer on the gap map page

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6876307c3cb883328b64dd3bf0c1a0de