### PR TITLE
Add personal about page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -20,6 +20,7 @@
       <li><a href="{{ '/gpt-links-page.html' | relative_url }}" {% if page.url == '/gpt-links-page.html' %}class="active"{% endif %}>My Custom GPTs</a></li>
       <li><a href="{{ '/blog_summary.html' | relative_url }}" {% if page.url == '/blog_summary.html' %}class="active"{% endif %}>Blog Summary</a></li>
       <li><a href="{{ '/blog.html' | relative_url }}" {% if page.url == '/blog.html' %}class="active"{% endif %}>Blog</a></li>
+      <li><a href="{{ '/about_me.html' | relative_url }}" {% if page.url == '/about_me.html' %}class="active"{% endif %}>About Me</a></li>
       <li><a href="{{ '/about_the_site.html' | relative_url }}" {% if page.url == '/about_the_site.html' %}class="active"{% endif %}>About the site</a></li>
       <li><a href="{{ '/sitemap.html' | relative_url }}" {% if page.url == '/sitemap.html' %}class="active"{% endif %}>Sitemap</a></li>
     </ul>

--- a/about_me.md
+++ b/about_me.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: About Me
+schema_type: AboutPage
+tags: [ProjectManagement, AI, Personal]
+---
+
+<header>
+  <h1>Lawrence Rowland</h1>
+  <p>AI &amp; Project Management</p>
+</header>
+
+<section id="methodologies">
+  <h2>AI-Driven Project Management Methodologies</h2>
+  <ul>
+    <li>GPTs as low-code tools for project teams</li>
+    <li>Custom GPTs with domain-specific project knowledge</li>
+    <li>AI-augmented communication and documentation</li>
+    <li>Retrieval-Augmented Generation (RAG) for document use</li>
+    <li>AI agents with defined project roles (e.g., risk analyst)</li>
+    <li>Flywheel of AI learning through early adoption</li>
+  </ul>
+</section>
+
+<section id="experiments">
+  <h2>Experiments in AI for Projects</h2>
+  <ul>
+    <li>GPT-to-GPT collaboration on project strategy and literature</li>
+    <li>Role-based AI agents simulating project team interactions</li>
+    <li>"Thinking" agents that operate asynchronously</li>
+    <li>Ontology-driven app-building using AI coders</li>
+  </ul>
+</section>
+
+<section id="frameworks">
+  <h2>Frameworks &amp; Predictions</h2>
+  <ul>
+    <li>Project GPT Framework: AI-augmented team models</li>
+    <li>Thinker vs Builder agents: classification for delegation</li>
+    <li>AI Flywheel: compounding benefits of early AI use</li>
+    <li>Democratisation: making PM tools accessible via AI</li>
+    <li>Ethical governance: transparency and validation</li>
+  </ul>
+</section>
+
+<section id="manifesto">
+  <h2>Manifesto for Running Projects with AI</h2>
+  <ol>
+    <li>AI as collaborator, not replacement</li>
+    <li>Embrace experimentation</li>
+    <li>Democratize project management</li>
+    <li>Prioritize knowledge flow</li>
+    <li>Maintain human judgment</li>
+    <li>Ensure transparency</li>
+    <li>Focus on value creation</li>
+  </ol>
+</section>
+
+<section id="publications">
+  <h2>Publications &amp; Media</h2>
+  <ul>
+    <li>Substack: <em>Experiment in AI</em></li>
+    <li>LinkedIn Series: <em>Daily AI Project Tips</em></li>
+    <li>Interviews: Project Chatter Podcast, MPA Podcast</li>
+  </ul>
+</section>
+
+<section id="contact">
+  <h2>Contact</h2>
+  <p>To discuss AI implementation in your project environment, reach out via LinkedIn or Substack.</p>
+</section>
+
+<footer>
+  <p>&copy; 2025 Lawrence Rowland. All rights reserved.</p>
+</footer>


### PR DESCRIPTION
## Summary
- add a new About Me page describing Lawrence Rowland's AI project work
- link the new page from the site navigation

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_6883d31879bc83329753f0c13c903665