### PR TITLE
Add Gallic Wars rivers entry and instructions

### DIFF
--- a/wider-interest/caesars_gallic_wars_rivers.html
+++ b/wider-interest/caesars_gallic_wars_rivers.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset='utf-8'/>
-<title>Gallic Wars French Rivers Gazetteer</title>
+<title>Each sentence mentioning a river in Caesar's Gallic Wars</title>
 <link rel='stylesheet' href='https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'/>
 <script src='https://unpkg.com/leaflet@1.9.4/dist/leaflet.js'></script>
 <style>
@@ -18,7 +18,11 @@
 </head>
 <body>
 <div id='list'>
-  <div id='info'>Click a sequence number to view details.</div>
+  <div id='info'>
+    <h1>Each sentence mentioning a river in Caesar's Gallic Wars</h1>
+    <p><strong>How to:</strong> click on a sequence number, see the sentence and the river, and see on the map the river highlighted.</p>
+    <p><strong>What is this:</strong> I was reading Caesar's Gallic Wars. I noticed that his mental geography is highly linked to the rivers, and at the same time, that my knowledge of French rivers was very poor. So I asked ChatGPT agent to create a gazetteer, which would allow me, as I came across a sentence in the book, to see straight away that river. The sentences are in the order found in the book.</p>
+  </div>
   <div id='items'></div>
 </div>
 <div id='map'></div>

--- a/wider-interest/index.md
+++ b/wider-interest/index.md
@@ -10,3 +10,4 @@ This section gathers topics outside the main theme of the site.
 
 - [John Burnet of Barn's journey](john-burnet-of-barns-journey.html)
 - [Johnson's Dictionary Project](johnsons-dictionary-project.html)
+- [Caesar's Gallic Wars Rivers](caesars_gallic_wars_rivers.html)


### PR DESCRIPTION
## Summary
- Link the new Gallic Wars rivers gazetteer from the Wider Interest index.
- Clarify the Gallic Wars rivers page with a title, usage instructions, and project background.

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a647052708833290853151cc4d35de